### PR TITLE
set AuthenticationType of JwtBearer TokenValidationParameters

### DIFF
--- a/src/SimpleAuthentication/JwtBearer/JwtBearerService.cs
+++ b/src/SimpleAuthentication/JwtBearer/JwtBearerService.cs
@@ -37,6 +37,7 @@ internal class JwtBearerService(IOptions<JwtBearerSettings> jwtBearerSettingsOpt
     {
         var tokenValidationParameters = new TokenValidationParameters
         {
+            AuthenticationType = jwtBearerSettings.SchemeName,
             NameClaimType = jwtBearerSettings.NameClaimType,
             RoleClaimType = jwtBearerSettings.RoleClaimType,
             ValidateIssuer = jwtBearerSettings.Issuers?.Any() ?? false,

--- a/src/SimpleAuthentication/SimpleAuthenticationExtensions.cs
+++ b/src/SimpleAuthentication/SimpleAuthenticationExtensions.cs
@@ -96,6 +96,7 @@ public static class SimpleAuthenticationExtensions
             {
                 options.TokenValidationParameters = new()
                 {
+                    AuthenticationType = settings.SchemeName,
                     NameClaimType = settings.NameClaimType,
                     RoleClaimType = settings.RoleClaimType,
                     ValidateIssuer = settings.Issuers?.Any() ?? false,


### PR DESCRIPTION
This PR fixes ```HttpContext.User.Identity.AuthenticationType``` not being set correctly when authenticating with JwtBearer.

Given the following endpoint and appsettings:
```
app.MapGet("api/me", (ClaimsPrincipal user) =>
{
    return new
    {
        user?.Identity?.AuthenticationType
    };
})
```
```
"Authentication": {
  "JwtBearer": {
      "SchemeName": "my_JwtBearer_scheme",
      ...
  },
  "ApiKey": {
      "SchemeName": "my_ApiKey_scheme",
      ...
  },
  "Basic": {
      "SchemeName": "my_Basic_scheme",
      ...
  }
}
```
Authenticating with Basic will return ```{
  "authenticationType": "my_Basic_scheme"
}```
and authenticating with ApiKey will return ```{
  "authenticationType": "my_ApiKey_scheme"
}```.
However authenticating with JwtBearer will currently return ```{
  "authenticationType": "AuthenticationTypes.Federation"
}``` instead the expected ```{
  "authenticationType": "my_JwtBearer_scheme"
}```.

