### PR TITLE
Update Swashbuckle.AspNetCore packages to 6.9.0

### DIFF
--- a/samples/Controllers/ApiKeySample/ApiKeySample.csproj
+++ b/samples/Controllers/ApiKeySample/ApiKeySample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Controllers/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/Controllers/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Controllers/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/Controllers/JwtBearerSample/JwtBearerSample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.8.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
+++ b/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -32,7 +32,7 @@
 
     <ItemGroup>
         <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="2.1.5" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.8.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.9.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated Swashbuckle.AspNetCore from 6.8.1 to 6.9.0 across multiple .csproj files:
- ApiKeySample.csproj
- BasicAuthenticationSample.csproj
- JwtBearerSample.csproj

In JwtBearerSample.csproj, also updated Swashbuckle.AspNetCore.Annotations from 6.8.1 to 6.9.0.

In SimpleAuthentication.csproj, updated Swashbuckle.AspNetCore.SwaggerGen from 6.8.1 to 6.9.0.