### PR TITLE
Update .NET version in GitHub Actions workflows to 9.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '8.x'
+  NET_VERSION: '9.x'
   PROJECT_NAME: src/SimpleAuthentication 
   PROJECT_FILE: SimpleAuthentication.csproj
   RELEASE_NAME: SimpleAuthenticationTools

--- a/.github/workflows/publish_abstractions.yml
+++ b/.github/workflows/publish_abstractions.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '8.x'
+  NET_VERSION: '9.x'
   PROJECT_NAME: src/SimpleAuthentication.Abstractions 
   PROJECT_FILE: SimpleAuthentication.Abstractions.csproj
   TAG_NAME: abstractions


### PR DESCRIPTION
Updated the .NET version from 8.x to 9.x in the GitHub Actions workflow files `publish.yml` and `publish_abstractions.yml`. This ensures that the workflows will now use .NET version 9.x for their operations.