### PR TITLE
Update package versions and add OAuth2 Swagger support

### DIFF
--- a/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
+++ b/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 

--- a/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 

--- a/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
     </ItemGroup>
 

--- a/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
+++ b/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.12,9.0.0)" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.112"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,11 +28,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.xml
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.xml
@@ -61,5 +61,26 @@
             <seealso cref="T:Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions"/>
             <seealso cref="T:Microsoft.Extensions.Configuration.IConfiguration"/>
         </member>
+        <member name="M:SimpleAuthentication.SwaggerExtensions.AddOAuth2Authentication(Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions,System.String,System.String,System.String,System.Collections.Generic.IDictionary{System.String,System.String})">
+            <summary>
+            Adds OAuth2 custom authentication support in Swagger, for example for example to integrate with Microsoft.Identity.Web.
+            </summary>
+            <param name="options">The <see cref="T:Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions"/> to add configuration to.</param>
+            <param name="name">The name of the OAuth2 authentication scheme to add.</param>
+            <param name="authorizationUrl">The Authorization Url for OAuth2 authorization.</param>
+            <param name="tokenUrl">The Token Url for OAuth2 authorization.</param>
+            <param name="scopes">The list of scopes.</param>
+            <seealso cref="T:Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions"/>
+        </member>
+        <member name="M:SimpleAuthentication.SwaggerExtensions.AddOAuth2Authentication(Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions,System.String,Microsoft.OpenApi.Models.OpenApiOAuthFlow)">
+            <summary>
+            Adds OAuth2 custom authentication support in Swagger, for example for example to integrate with Microsoft.Identity.Web.
+            </summary>
+            <param name="options">The <see cref="T:Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions"/> to add configuration to.</param>
+            <param name="name">The name of the OAuth2 authentication scheme to add.</param>
+            <param name="authFlow">The <see cref="T:Microsoft.OpenApi.Models.OpenApiOAuthFlow">object</see> that describes the authorization flow.</param>
+            <seealso cref="T:Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions"/>
+            <seealso cref="T:Microsoft.OpenApi.Models.OpenApiOAuthFlow"/>
+        </member>
     </members>
 </doc>


### PR DESCRIPTION
This pull request includes several updates to package references and the addition of new XML documentation for OAuth2 authentication support in Swagger. The most important changes are:

### Package Reference Updates:
* Updated `Microsoft.AspNetCore.OpenApi` to version 9.0.1 in `ApiKeySample.csproj`, `BasicAuthenticationSample.csproj`, and `JwtBearerSample.csproj` files. [[1]](diffhunk://#diff-1b25a898c216d720806994f195686b363b36fdfd73472ddfbdd595461995c040L10-R10) [[2]](diffhunk://#diff-f932886861b8299e3bb0fde0d0125281c9326dba5050026e02173d930e99f23eL10-R10)
* Updated `Microsoft.AspNetCore.OpenApi` to version [8.0.12,9.0.0) in `Net8JwtBearerSample.csproj`.
* Updated `Nerdbank.GitVersioning` to version 3.7.115 in `Directory.Build.props`.
* Updated `Microsoft.AspNetCore.Authentication.JwtBearer` to versions 8.0.12 and 9.0.1 in `SimpleAuthentication.Abstractions.csproj`.

### Documentation Additions:
* Added XML documentation for `AddOAuth2Authentication` methods in `SimpleAuthentication.Swashbuckle.xml` to support OAuth2 custom authentication in Swagger.