### PR TITLE
Update package versions for OpenApi and JwtBearer

### DIFF
--- a/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
+++ b/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 

--- a/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 

--- a/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
     </ItemGroup>
 

--- a/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
+++ b/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.12,9.0.0)" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.13,9.0.0)" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,11 +28,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.13" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
This pull request includes updates to various project files to upgrade the versions of several package dependencies. The most important changes include updating the `Microsoft.AspNetCore.OpenApi` and `Microsoft.AspNetCore.Authentication.JwtBearer` package versions across multiple project files.

Dependency updates:

* [`samples/MinimalApis/ApiKeySample/ApiKeySample.csproj`](diffhunk://#diff-1b25a898c216d720806994f195686b363b36fdfd73472ddfbdd595461995c040L10-R10): Updated `Microsoft.AspNetCore.OpenApi` package version from `9.0.1` to `9.0.2`.
* [`samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj`](diffhunk://#diff-1b25a898c216d720806994f195686b363b36fdfd73472ddfbdd595461995c040L10-R10): Updated `Microsoft.AspNetCore.OpenApi` package version from `9.0.1` to `9.0.2`.
* [`samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj`](diffhunk://#diff-f932886861b8299e3bb0fde0d0125281c9326dba5050026e02173d930e99f23eL10-R10): Updated `Microsoft.AspNetCore.OpenApi` package version from `9.0.1` to `9.0.2`.
* [`samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj`](diffhunk://#diff-d81d6f885b2c4247b6e7c812c6eaf1f3c55ca16e20f47d9001b63ebf33bf6318L10-R10): Updated `Microsoft.AspNetCore.OpenApi` package version from `[8.0.12,9.0.0)` to `[8.0.13,9.0.0)`.
* [`src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj`](diffhunk://#diff-11ea3c191ac94f733fa13b6ca9145836a48f59500701a3b57df88005f1bb0334L31-R35): Updated `Microsoft.AspNetCore.Authentication.JwtBearer` package version for `net8.0` from `8.0.12` to `8.0.13` and for `net9.0` from `9.0.1` to `9.0.2`.