### PR TITLE
Integrate authentication with OpenAPI and update packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,21 +137,6 @@ builder.Services.AddOpenApi(options =>
 });
 ```
 
-> [!IMPORTANT]  
-> ***Known issue***
-> Currently, to make the `AddSimpleAuthentication` extension method work with `AddOpenApi`, you need to have at least one endpoint that produces a **Problem** response, for example:
-
-```csharp
-app.MapPost("api/auth/login", () =>
-{
-    // ...
-
-})
-.ProducesProblem(StatusCodes.Status400BadRequest);
-```
-
-This is a workaround that will be fixed in the next release.
-
 **Creating a JWT Bearer**
 
 When using JWT Bearer authentication, you can set the _EnableJwtBearerService_ setting to _true_ to automatically register an implementation of the [IJwtBearerService](https://github.com/marcominerva/SimpleAuthentication/blob/master/src/SimpleAuthentication.Abstractions/JwtBearer/IJwtBearerService.cs) interface to create a valid JWT Bearer, according to the setting you have specified in the _appsettings.json_ file:

--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.3" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.4" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication/OpenApi/DefaultResponseDocumentTransformer.cs
+++ b/src/SimpleAuthentication/OpenApi/DefaultResponseDocumentTransformer.cs
@@ -1,0 +1,63 @@
+﻿#if NET9_0_OR_GREATER
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+namespace SimpleAuthentication.OpenApi;
+
+internal class DefaultResponseDocumentTransformer : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        // Checks if the ProblemDetails type is already defined in the document (because there is at least one endpoint that returns it).
+        var isProblemDetailsSchemaDefined = context.DescriptionGroups
+           .SelectMany(g => g.Items).SelectMany(i => i.SupportedResponseTypes)
+           .Any(type => type.Type == typeof(ProblemDetails));
+
+        if (isProblemDetailsSchemaDefined)
+        {
+            return Task.CompletedTask;
+        }
+
+        // Otherwise, define the ProblemDetails schema in the document.
+        document.Components ??= new();
+        document.Components.Schemas.TryAdd(nameof(ProblemDetails), new OpenApiSchema
+        {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                ["type"] = new()
+                {
+                    Type = "string",
+                    Nullable = true
+                },
+                ["title"] = new()
+                {
+                    Type = "string",
+                    Nullable = true
+                },
+                ["status"] = new()
+                {
+                    Type = "integer",
+                    Format = "int32",
+                    Nullable = true
+                },
+                ["detail"] = new()
+                {
+                    Type = "string",
+                    Nullable = true
+                },
+                ["instance"] = new()
+                {
+                    Type = "string",
+                    Nullable = true
+                }
+            }
+        });
+
+        return Task.CompletedTask;
+    }
+}
+
+#endif

--- a/src/SimpleAuthentication/OpenApiExtensions.cs
+++ b/src/SimpleAuthentication/OpenApiExtensions.cs
@@ -76,6 +76,7 @@ public static class OpenApiExtensions
         ArgumentNullException.ThrowIfNull(sectionName);
 
         options.AddDocumentTransformer(new AuthenticationDocumentTransformer(configuration, sectionName, additionalSecurityRequirements));
+        options.AddDocumentTransformer<DefaultResponseDocumentTransformer>();
         options.AddOperationTransformer<AuthenticationOperationTransformer>();
     }
 

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.3" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.4" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request includes several updates and improvements to the SimpleAuthentication library, primarily focusing on OpenAPI integration and dependency updates. The most important changes include the addition of a new document transformer to handle `ProblemDetails`, removal of a known issue workaround from the documentation, and updates to package dependencies.

### OpenAPI Integration:

* Added `DefaultResponseDocumentTransformer` to define the `ProblemDetails` schema in OpenAPI documents if not already present. (`src/SimpleAuthentication/OpenApi/DefaultResponseDocumentTransformer.cs`)
* Updated `AddSimpleAuthentication` extension method to include the new `DefaultResponseDocumentTransformer`. (`src/SimpleAuthentication/OpenApiExtensions.cs`)

### Documentation:

* Removed the known issue workaround related to the `AddSimpleAuthentication` method requiring an endpoint that produces a `Problem` response. (`README.md`)

### Dependency Updates:

* Updated `SimpleAuthenticationTools.Abstractions` package version from 3.0.3 to 3.0.4 in both `SimpleAuthentication.Swashbuckle.csproj` and `SimpleAuthentication.csproj`. (`src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj`, `src/SimpleAuthentication/SimpleAuthentication.csproj`) [[1]](diffhunk://#diff-6356107e927ab895351878545eef23df3410127fc2187dac38ce9ee26d09e508L35-R35) [[2]](diffhunk://#diff-8fdd919686539fd12c7f59febcb4765391375c09133aebd41ab51c3505be77b7L38-R38)