### PR TITLE
Update Swashbuckle.AspNetCore to version 7.3.0

### DIFF
--- a/samples/Controllers/ApiKeySample/ApiKeySample.csproj
+++ b/samples/Controllers/ApiKeySample/ApiKeySample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Controllers/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/Controllers/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Controllers/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/Controllers/JwtBearerSample/JwtBearerSample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
+++ b/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
+++ b/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.13,9.0.0)" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
@@ -33,7 +33,7 @@
 
     <ItemGroup>
         <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.4" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated the `Swashbuckle.AspNetCore` package from `7.2.0` to `7.3.0` across multiple `.csproj` files, including `ApiKeySample.csproj`, `BasicAuthenticationSample.csproj`, `JwtBearerSample.csproj`, `Net8JwtBearerSample.csproj`, and `SimpleAuthentication.Swashbuckle.csproj`. The `JwtBearerSample.csproj` also updates `Swashbuckle.AspNetCore.Annotations` and `Swashbuckle.AspNetCore.SwaggerUI` to version `7.3.0`. These changes ensure all projects are using the latest version, which may include new features, improvements, or bug fixes.