### PR TITLE
Update libraries

### DIFF
--- a/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
+++ b/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
     </ItemGroup>
 

--- a/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
     </ItemGroup>
 

--- a/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.1" />
     </ItemGroup>
 

--- a/samples/MinimalApis/JwtBearerSample/Program.cs
+++ b/samples/MinimalApis/JwtBearerSample/Program.cs
@@ -78,7 +78,11 @@ authApiGroup.MapPost("login", async (LoginRequest loginRequest, DateTime? expira
     // Check for login rights...
 
     // Add custom claims (optional).
-    var claims = new List<Claim>();
+    var claims = new List<Claim>
+    {
+        new(ClaimTypes.Role, "Administrator")
+    };
+
     if (!string.IsNullOrWhiteSpace(loginRequest.Scopes))
     {
         claims.Add(new("scp", loginRequest.Scopes));

--- a/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
+++ b/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.13,9.0.0)" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.14,9.0.0)" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,11 +28,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.13" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/SimpleAuthentication/PermissionAuthorizationExtensions.cs
+++ b/src/SimpleAuthentication/PermissionAuthorizationExtensions.cs
@@ -18,7 +18,6 @@ public static class PermissionAuthorizationExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
     /// <remarks>The <see cref="IPermissionHandler"/> implementation is registered as <see cref="ServiceLifetime.Transient"/>.</remarks>
-    /// <exception cref="ArgumentNullException">One or more required configuration settings are missing.</exception>
     /// <seealso cref="IPermissionHandler"/>
     public static IServiceCollection AddPermissions<T>(this IServiceCollection services) where T : class, IPermissionHandler
     {
@@ -38,7 +37,6 @@ public static class PermissionAuthorizationExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
     /// <remarks>The <see cref="ScopeClaimPermissionHandler"/> is registered as <see cref="ServiceLifetime.Transient"/>.</remarks>
-    /// <exception cref="ArgumentNullException">One or more required configuration settings are missing.</exception>
     /// <seealso cref="ScopeClaimPermissionHandler"/>
     public static IServiceCollection AddScopePermissions(this IServiceCollection services)
         => services.AddPermissions<ScopeClaimPermissionHandler>();
@@ -50,7 +48,6 @@ public static class PermissionAuthorizationExtensions
     /// <param name="builder">The <see cref="AuthenticationBuilder"/> to add services to.</param>
     /// <returns>An <see cref="AuthenticationBuilder"/> that can be used to further customize authentication.</returns>
     /// <remarks>The <see cref="IPermissionHandler"/> implementation is registered as <see cref="ServiceLifetime.Transient"/>.</remarks>
-    /// <exception cref="ArgumentNullException">One or more required configuration settings are missing.</exception>
     /// <seealso cref="IPermissionHandler"/>
     /// <seealso cref="AuthenticationBuilder"/>
     public static AuthenticationBuilder AddPermissions<T>(this AuthenticationBuilder builder) where T : class, IPermissionHandler
@@ -65,7 +62,6 @@ public static class PermissionAuthorizationExtensions
     /// <param name="builder">The <see cref="AuthenticationBuilder"/> to add services to.</param>
     /// <returns>An <see cref="AuthenticationBuilder"/> that can be used to further customize authentication.</returns>
     /// <remarks>The <see cref="ScopeClaimPermissionHandler"/> is registered as <see cref="ServiceLifetime.Transient"/>.</remarks>
-    /// <exception cref="ArgumentNullException">One or more required configuration settings are missing.</exception>
     /// <seealso cref="IPermissionHandler"/>
     /// <seealso cref="ScopeClaimPermissionHandler"/>
     /// <seealso cref="AuthenticationBuilder"/>    
@@ -81,7 +77,6 @@ public static class PermissionAuthorizationExtensions
     /// <param name="builder">The <see cref="AuthorizationPolicyBuilder"/> to add policy to.</param>
     /// <param name="permissions">The list of permissions to add.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    /// <exception cref="ArgumentNullException">One or more required configuration settings are missing.</exception>
     /// <seealso cref="AuthorizationPolicyBuilder"/>
     /// <seealso cref="PermissionRequirement"/>
     public static AuthorizationPolicyBuilder RequirePermission(this AuthorizationPolicyBuilder builder, params string[] permissions)
@@ -97,7 +92,6 @@ public static class PermissionAuthorizationExtensions
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/> to add policy to.</param>
     /// <param name="permissions">The permission list to require for authorization.</param>
     /// <returns>The original <see cref="IEndpointConventionBuilder"/> parameter.</returns>
-    /// <exception cref="ArgumentNullException">One or more required configuration settings are missing.</exception>
     /// <seealso cref="IEndpointConventionBuilder"/>
     public static TBuilder RequirePermission<TBuilder>(this TBuilder builder, params string[] permissions) where TBuilder : IEndpointConventionBuilder
     {

--- a/src/SimpleAuthentication/RoleAuthorizationExtensions.cs
+++ b/src/SimpleAuthentication/RoleAuthorizationExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+
+namespace SimpleAuthentication;
+
+/// <summary>
+/// Provides extension methods for adding role-based authorization support in ASP.NET Core.
+/// </summary>
+public static class RoleAuthorizationExtensions
+{
+    /// <summary>
+    /// Adds role-based authorization policy to the endpoint(s).
+    /// </summary>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/> to add policy to.</param>
+    /// <param name="roles">The role list to require for authorization.</param>
+    /// <returns>The original <see cref="IEndpointConventionBuilder"/> parameter.</returns>
+    /// <seealso cref="IEndpointConventionBuilder"/>
+    public static TBuilder RequireRole<TBuilder>(this TBuilder builder, params string[] roles) where TBuilder : IEndpointConventionBuilder
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.RequireAuthorization(new AuthorizeAttribute { Roles = string.Join(",", roles) });
+    }
+}

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request includes multiple changes to update package references, add role-based authorization, and clean up code comments. The most important changes include updating package versions, adding a new authorization extension, and removing redundant exception comments.

### Package Updates:
* Updated `Microsoft.AspNetCore.OpenApi` package to version `9.0.3` in various project files (`samples/MinimalApis/ApiKeySample/ApiKeySample.csproj`, `samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj`, `samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj`, `samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj`, `src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj`, `src/SimpleAuthentication/SimpleAuthentication.csproj`). [[1]](diffhunk://#diff-1b25a898c216d720806994f195686b363b36fdfd73472ddfbdd595461995c040L10-R10) [[2]](diffhunk://#diff-f932886861b8299e3bb0fde0d0125281c9326dba5050026e02173d930e99f23eL10-R10) [[3]](diffhunk://#diff-d81d6f885b2c4247b6e7c812c6eaf1f3c55ca16e20f47d9001b63ebf33bf6318L10-R10) [[4]](diffhunk://#diff-11ea3c191ac94f733fa13b6ca9145836a48f59500701a3b57df88005f1bb0334L31-R35) [[5]](diffhunk://#diff-8fdd919686539fd12c7f59febcb4765391375c09133aebd41ab51c3505be77b7L34-R34)
* Updated `Microsoft.AspNetCore.Authentication.JwtBearer` package to version `8.0.14` for .NET 8.0 and version `9.0.3` for .NET 9.0 in `src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj`.

### Authorization Enhancements:
* Added a new `RoleAuthorizationExtensions` class to provide extension methods for role-based authorization in ASP.NET Core (`src/SimpleAuthentication/RoleAuthorizationExtensions.cs`).
* Added a custom claim for "Administrator" role in `samples/MinimalApis/JwtBearerSample/Program.cs`.

### Code Cleanup:
* Removed redundant `ArgumentNullException` comments from `PermissionAuthorizationExtensions.cs` methods (`src/SimpleAuthentication/PermissionAuthorizationExtensions.cs`). [[1]](diffhunk://#diff-5e85a7a93669b35356eb18fab4e4aa190d838626f46b8937c42d23d1b6ed35e5L21) [[2]](diffhunk://#diff-5e85a7a93669b35356eb18fab4e4aa190d838626f46b8937c42d23d1b6ed35e5L41) [[3]](diffhunk://#diff-5e85a7a93669b35356eb18fab4e4aa190d838626f46b8937c42d23d1b6ed35e5L53) [[4]](diffhunk://#diff-5e85a7a93669b35356eb18fab4e4aa190d838626f46b8937c42d23d1b6ed35e5L68) [[5]](diffhunk://#diff-5e85a7a93669b35356eb18fab4e4aa190d838626f46b8937c42d23d1b6ed35e5L84) [[6]](diffhunk://#diff-5e85a7a93669b35356eb18fab4e4aa190d838626f46b8937c42d23d1b6ed35e5L100)