### PR TITLE
Update SimpleAuthenticationTools.Abstractions version

### DIFF
--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.4" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.5" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.1" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.4" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated the `SimpleAuthenticationTools.Abstractions` package from version `3.0.4` to `3.0.5` in both `SimpleAuthentication.Swashbuckle.csproj` and `SimpleAuthentication.csproj` files.