### PR TITLE
Update JwtBearer package versions in project file

### DIFF
--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,11 +28,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Updated the version of the `Microsoft.AspNetCore.Authentication.JwtBearer` package for both the `net8.0` and `net9.0` target frameworks in the `SimpleAuthentication.Abstractions.csproj` file. The version was changed from `8.0.14` to `8.0.15` for `net8.0`, and from `9.0.3` to `9.0.4` for `net9.0`.