### PR TITLE
Update JwtBearer package versions in project file

### DIFF
--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,11 +28,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Updated `Microsoft.AspNetCore.Authentication.JwtBearer` from `8.0.15` to `8.0.16` for `net8.0` and from
`9.0.4` to `9.0.5` for `net9.0` in
`SimpleAuthentication.Abstractions.csproj`.