### PR TITLE
Update package versions for OpenApi and SimpleAuth tools

### DIFF
--- a/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
+++ b/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     </ItemGroup>
 

--- a/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     </ItemGroup>
 

--- a/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
     </ItemGroup>
 

--- a/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
+++ b/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.14,9.0.0)" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.16,9.0.0)" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.6" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.7" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.6" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.7" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Updated `Microsoft.AspNetCore.OpenApi` from `9.0.4` to `9.0.5` in `ApiKeySample.csproj`, `BasicAuthenticationSample.csproj`, and `JwtBearerSample.csproj`.
- Changed `Microsoft.AspNetCore.OpenApi` version constraint from `[8.0.14,9.0.0)` to `[8.0.16,9.0.0)` in `Net8JwtBearerSample.csproj`.
- Upgraded `SimpleAuthenticationTools.Abstractions` from `3.0.6` to `3.0.7` in `SimpleAuthentication.Swashbuckle.csproj` and `SimpleAuthentication.csproj`.