### PR TITLE
Update Swashbuckle.AspNetCore packages to 8.1.3

### DIFF
--- a/samples/Controllers/ApiKeySample/ApiKeySample.csproj
+++ b/samples/Controllers/ApiKeySample/ApiKeySample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Controllers/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/Controllers/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Controllers/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/Controllers/JwtBearerSample/JwtBearerSample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
+++ b/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
+++ b/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.16,9.0.0)" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
@@ -33,7 +33,7 @@
 
     <ItemGroup>
         <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated the version of `Swashbuckle.AspNetCore` and related packages from `8.1.2` to `8.1.3` in multiple project files, including `ApiKeySample.csproj`, `BasicAuthenticationSample.csproj`, `JwtBearerSample.csproj`, `Net8JwtBearerSample.csproj`, and `SimpleAuthentication.Swashbuckle.csproj`. The `Swashbuckle.AspNetCore.Annotations` package was also updated to `8.1.3` in `JwtBearerSample.csproj`. These updates ensure compatibility with the latest features and fixes.