### PR TITLE
Update JwtBearer package versions for net8.0 and net9.0

### DIFF
--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,11 +28,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Updated the `Microsoft.AspNetCore.Authentication.JwtBearer` package:
- Changed version from `8.0.16` to `8.0.17` for `net8.0`.
- Changed version from `9.0.5` to `9.0.6` for `net9.0`.