### PR TITLE
Refactor security scheme naming in AuthDocumentTransformer

### DIFF
--- a/src/SimpleAuthentication/OpenApi/AuthenticationDocumentTransformer.cs
+++ b/src/SimpleAuthentication/OpenApi/AuthenticationDocumentTransformer.cs
@@ -53,14 +53,18 @@ internal class AuthenticationDocumentTransformer(IConfiguration configuration, s
 
             if (!string.IsNullOrWhiteSpace(settings.HeaderName))
             {
-                AddSecurityScheme(document, $"{settings.SchemeName} in Header", SecuritySchemeType.ApiKey, null, ParameterLocation.Header, settings.HeaderName, "Insert the API Key");
-                AddSecurityRequirement(document, $"{settings.SchemeName} in Header");
+                var schemeName = $"{settings.SchemeName}-Header";
+
+                AddSecurityScheme(document, schemeName, SecuritySchemeType.ApiKey, null, ParameterLocation.Header, settings.HeaderName, "Insert the API Key");
+                AddSecurityRequirement(document, schemeName);
             }
 
             if (!string.IsNullOrWhiteSpace(settings.QueryStringKey))
             {
-                AddSecurityScheme(document, $"{settings.SchemeName} in Query String", SecuritySchemeType.ApiKey, null, ParameterLocation.Query, settings.QueryStringKey, "Insert the API Key");
-                AddSecurityRequirement(document, $"{settings.SchemeName} in Query String");
+                var schemeName = $"{settings.SchemeName}-QueryString";
+
+                AddSecurityScheme(document, schemeName, SecuritySchemeType.ApiKey, null, ParameterLocation.Query, settings.QueryStringKey, "Insert the API Key");
+                AddSecurityRequirement(document, schemeName);
             }
         }
 


### PR DESCRIPTION
Updated the naming convention for security schemes in the `AuthenticationDocumentTransformer` class. The new format appends a suffix to the scheme name (e.g., "-Header" and "-QueryString") instead of using descriptive phrases. This change enhances consistency and clarity in the generated documentation for both header and query string security schemes.

Refactor security scheme naming in OpenAPI document

This update changes the naming convention for security schemes added to the OpenAPI document. Instead of descriptive strings that include the scheme name and location, the new implementation appends a suffix to the scheme name (e.g., `"{settings.SchemeName}-Header"` for headers and `"{settings.SchemeName}-QueryString"` for query strings). This improves consistency, clarity, and maintainability of the security scheme definitions.