### PR TITLE
Update OpenAPI and Swagger configurations

### DIFF
--- a/samples/Controllers/ApiKeySample/ApiKeySample.csproj
+++ b/samples/Controllers/ApiKeySample/ApiKeySample.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\SimpleAuthentication.Swashbuckle\SimpleAuthentication.Swashbuckle.csproj" />
-    <ProjectReference Include="..\..\..\src\SimpleAuthentication\SimpleAuthentication.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\SimpleAuthentication.Swashbuckle\SimpleAuthentication.Swashbuckle.csproj" />
+        <ProjectReference Include="..\..\..\src\SimpleAuthentication\SimpleAuthentication.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/samples/Controllers/ApiKeySample/Program.cs
+++ b/samples/Controllers/ApiKeySample/Program.cs
@@ -32,10 +32,7 @@ builder.Services.AddTransient<IApiKeyValidator, CustomApiKeyValidator>();
 
 builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-
-builder.Services.AddSwaggerGen(options =>
+builder.Services.AddOpenApi(options =>
 {
     options.AddSimpleAuthentication(builder.Configuration);
 });
@@ -45,18 +42,15 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
 
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler();
-}
-
+app.UseExceptionHandler();
 app.UseStatusCodePages();
 
-if (app.Environment.IsDevelopment())
+app.MapOpenApi();
+
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    options.SwaggerEndpoint("/openapi/v1.json", app.Environment.ApplicationName);
+});
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/samples/Controllers/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/Controllers/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\SimpleAuthentication.Swashbuckle\SimpleAuthentication.Swashbuckle.csproj" />
-    <ProjectReference Include="..\..\..\src\SimpleAuthentication\SimpleAuthentication.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\SimpleAuthentication.Swashbuckle\SimpleAuthentication.Swashbuckle.csproj" />
+        <ProjectReference Include="..\..\..\src\SimpleAuthentication\SimpleAuthentication.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/samples/Controllers/BasicAuthenticationSample/Program.cs
+++ b/samples/Controllers/BasicAuthenticationSample/Program.cs
@@ -33,10 +33,7 @@ builder.Services.AddTransient<IBasicAuthenticationValidator, CustomBasicAuthenti
 
 builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-
-builder.Services.AddSwaggerGen(options =>
+builder.Services.AddOpenApi(options =>
 {
     options.AddSimpleAuthentication(builder.Configuration);
 });
@@ -46,18 +43,15 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
 
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler();
-}
-
+app.UseExceptionHandler();
 app.UseStatusCodePages();
 
-if (app.Environment.IsDevelopment())
+app.MapOpenApi();
+
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    options.SwaggerEndpoint("/openapi/v1.json", app.Environment.ApplicationName);
+});
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/samples/Controllers/JwtBearerSample/Controllers/AuthController.cs
+++ b/samples/Controllers/JwtBearerSample/Controllers/AuthController.cs
@@ -2,7 +2,6 @@ using System.Net.Mime;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using SimpleAuthentication.JwtBearer;
-using Swashbuckle.AspNetCore.Annotations;
 
 namespace JwtBearerSample.Controllers;
 
@@ -14,7 +13,7 @@ public class AuthController(IJwtBearerService jwtBearerService) : ControllerBase
     [HttpPost("login")]
     [ProducesResponseType<LoginResponse>(StatusCodes.Status200OK)]
     [ProducesDefaultResponseType]
-    [SwaggerOperation(description: "Insert permissions in the scope property (for example: 'profile people:admin')")]
+    [EndpointDescription(description: "Insert permissions in the scope property (for example: 'profile people:admin')")]
     public async Task<ActionResult<LoginResponse>> Login(LoginRequest loginRequest, DateTime? expiration = null)
     {
         // Check for login rights...

--- a/samples/Controllers/JwtBearerSample/Controllers/MeController.cs
+++ b/samples/Controllers/JwtBearerSample/Controllers/MeController.cs
@@ -2,7 +2,6 @@ using System.Net.Mime;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SimpleAuthentication.Permissions;
-using Swashbuckle.AspNetCore.Annotations;
 
 namespace JwtBearerSample.Controllers;
 
@@ -16,7 +15,7 @@ public class MeController : ControllerBase
     [HttpGet]
     [ProducesResponseType<User>(StatusCodes.Status200OK)]
     [ProducesDefaultResponseType]
-    [SwaggerOperation(description: "This endpoint requires the 'profile' permission")]
+    [EndpointDescription(description: "This endpoint requires the 'profile' permission")]
     public ActionResult<User> Get()
         => new User(User.Identity!.Name);
 }

--- a/samples/Controllers/JwtBearerSample/Controllers/PeopleController.cs
+++ b/samples/Controllers/JwtBearerSample/Controllers/PeopleController.cs
@@ -2,7 +2,6 @@ using System.Net.Mime;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SimpleAuthentication.Permissions;
-using Swashbuckle.AspNetCore.Annotations;
 
 namespace JwtBearerSample.Controllers;
 
@@ -14,35 +13,35 @@ public class PeopleController : ControllerBase
 {
     [Authorize(Policy = "PeopleRead")] // [Permissions(Permissions.PeopleRead, Permissions.PeopleAdmin)]
     [HttpGet]
-    [SwaggerOperation(description: $"This endpoint requires the '{Permissions.PeopleRead}' or '{Permissions.PeopleAdmin}' permissions")]
+    [EndpointDescription(description: $"This endpoint requires the '{Permissions.PeopleRead}' or '{Permissions.PeopleAdmin}' permissions")]
     public IActionResult GetList() => NoContent();
 
     [Authorize(Policy = "PeopleRead")] // [Permissions(Permissions.PeopleRead, Permissions.PeopleAdmin)]
     [HttpGet("{id:int}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesDefaultResponseType]
-    [SwaggerOperation(description: $"This endpoint requires the '{Permissions.PeopleRead}' or '{Permissions.PeopleAdmin}' permissions")]
+    [EndpointDescription(description: $"This endpoint requires the '{Permissions.PeopleRead}' or '{Permissions.PeopleAdmin}' permissions")]
     public IActionResult GetPerson(int id) => NoContent();
 
     [Permission(Permissions.PeopleWrite)]
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesDefaultResponseType]
-    [SwaggerOperation(description: $"This endpoint requires the '{Permissions.PeopleWrite}' permission")]
+    [EndpointDescription(description: $"This endpoint requires the '{Permissions.PeopleWrite}' permission")]
     public IActionResult Insert() => NoContent();
 
     [Permission(Permissions.PeopleWrite)]
     [HttpPut]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesDefaultResponseType]
-    [SwaggerOperation(description: $"This endpoint requires the '{Permissions.PeopleWrite}' permission")]
+    [EndpointDescription(description: $"This endpoint requires the '{Permissions.PeopleWrite}' permission")]
     public IActionResult Update() => NoContent();
 
     [Permission(Permissions.PeopleAdmin)]
     [HttpDelete("{id:int}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesDefaultResponseType]
-    [SwaggerOperation(description: $"This endpoint requires the '{Permissions.PeopleAdmin}' permission")]
+    [EndpointDescription(description: $"This endpoint requires the '{Permissions.PeopleAdmin}' permission")]
     public IActionResult Delete(int id) => NoContent();
 }
 

--- a/samples/Controllers/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/Controllers/JwtBearerSample/JwtBearerSample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Controllers/JwtBearerSample/Program.cs
+++ b/samples/Controllers/JwtBearerSample/Program.cs
@@ -41,12 +41,8 @@ builder.Services.AddAuthorizationBuilder()
 
 builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-
-builder.Services.AddSwaggerGen(options =>
+builder.Services.AddOpenApi(options =>
 {
-    options.EnableAnnotations();
     options.AddSimpleAuthentication(builder.Configuration);
 });
 
@@ -55,18 +51,15 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
 
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler();
-}
-
+app.UseExceptionHandler();
 app.UseStatusCodePages();
 
-if (app.Environment.IsDevelopment())
+app.MapOpenApi();
+
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    options.SwaggerEndpoint("/openapi/v1.json", app.Environment.ApplicationName);
+});
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
+++ b/samples/MinimalApis/ApiKeySample/ApiKeySample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/ApiKeySample/Program.cs
+++ b/samples/MinimalApis/ApiKeySample/Program.cs
@@ -32,10 +32,7 @@ builder.Services.AddTransient<IApiKeyValidator, CustomApiKeyValidator>();
 
 builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-
-builder.Services.AddSwaggerGen(options =>
+builder.Services.AddOpenApi(options =>
 {
     options.AddSimpleAuthentication(builder.Configuration);
 });
@@ -45,18 +42,15 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
 
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler();
-}
-
+app.UseExceptionHandler();
 app.UseStatusCodePages();
 
-if (app.Environment.IsDevelopment())
+app.MapOpenApi();
+
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    options.SwaggerEndpoint("/openapi/v1.json", app.Environment.ApplicationName);
+});
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
+++ b/samples/MinimalApis/BasicAuthenticationSample/BasicAuthenticationSample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/BasicAuthenticationSample/Program.cs
+++ b/samples/MinimalApis/BasicAuthenticationSample/Program.cs
@@ -32,10 +32,7 @@ builder.Services.AddTransient<IBasicAuthenticationValidator, CustomBasicAuthenti
 
 builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-
-builder.Services.AddSwaggerGen(options =>
+builder.Services.AddOpenApi(options =>
 {
     options.AddSimpleAuthentication(builder.Configuration);
 });
@@ -45,18 +42,15 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
 
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler();
-}
-
+app.UseExceptionHandler();
 app.UseStatusCodePages();
 
-if (app.Environment.IsDevelopment())
+app.MapOpenApi();
+
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    options.SwaggerEndpoint("/openapi/v1.json", app.Environment.ApplicationName);
+});
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
+++ b/samples/MinimalApis/JwtBearerSample/JwtBearerSample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/JwtBearerSample/Program.cs
+++ b/samples/MinimalApis/JwtBearerSample/Program.cs
@@ -51,22 +51,15 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
 
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler();
-}
-
+app.UseExceptionHandler();
 app.UseStatusCodePages();
 
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
+app.MapOpenApi();
 
-    app.UseSwaggerUI(options =>
-    {
-        options.SwaggerEndpoint("/openapi/v1.json", builder.Environment.ApplicationName);
-    });
-}
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("/openapi/v1.json", builder.Environment.ApplicationName);
+});
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
+++ b/samples/MinimalApis/Net8JwtBearerSample/Net8JwtBearerSample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.18,9.0.0)" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.19,9.0.0)" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/Net8JwtBearerSample/Program.cs
+++ b/samples/MinimalApis/Net8JwtBearerSample/Program.cs
@@ -54,18 +54,11 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
 
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler();
-}
-
+app.UseExceptionHandler();
 app.UseStatusCodePages();
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -31,11 +31,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.10" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.0.11" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Replace `Swashbuckle.AspNetCore` with `Microsoft.AspNetCore.OpenApi` and `Swashbuckle.AspNetCore.SwaggerUI` in project files for `ApiKeySample`, `BasicAuthenticationSample`, and `JwtBearerSample`, upgrading versions to `9.0.4` and `9.0.8` respectively.
- Refactor `Program.cs` to use `AddOpenApi` and streamline Swagger UI setup with `MapOpenApi`.
- Replace Swagger annotations in `AuthController`, `MeController`, and `PeopleController` with `EndpointDescription`.
- Update `SimpleAuthentication` project to reflect new OpenAPI version.
- Enhance API documentation capabilities and ensure compatibility with latest libraries.