### PR TITLE
Switch to NuGet package for Abstractions

### DIFF
--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\SimpleAuthentication.Abstractions\SimpleAuthentication.Abstractions.csproj" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.3" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.6" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\SimpleAuthentication.Abstractions\SimpleAuthentication.Abstractions.csproj" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.3" />
     </ItemGroup>
 
     <ItemGroup>
@@ -45,5 +45,5 @@
         </None>
         <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
-    
+
 </Project>


### PR DESCRIPTION
Replaced `ProjectReference` with `PackageReference` in both `SimpleAuthentication.Swashbuckle.csproj` and `SimpleAuthentication.csproj`. The local project dependency on `SimpleAuthentication.Abstractions` is now replaced with the NuGet package `SimpleAuthenticationTools.Abstractions` version `3.1.3`.