### PR TITLE
Update package versions and add null checks

### DIFF
--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.3" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.4" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.6" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication/ApiKey/ApiKeyAuthenticationHandler.cs
+++ b/src/SimpleAuthentication/ApiKey/ApiKeyAuthenticationHandler.cs
@@ -45,9 +45,12 @@ internal class ApiKeyAuthenticationHandler(IOptionsMonitor<ApiKeySettings> optio
         if (apiKey is not null)
         {
             var claims = new List<Claim>();
-            foreach (var role in apiKey.Roles)
+            if (apiKey.Roles is not null)
             {
-                claims.Add(new(Options.RoleClaimType, role));
+                foreach (var role in apiKey.Roles)
+                {
+                    claims.Add(new(Options.RoleClaimType, role));
+                }
             }
 
             return CreateAuthenticationSuccessResult(apiKey.UserName, claims);

--- a/src/SimpleAuthentication/BasicAuthentication/BasicAuthenticationHandler.cs
+++ b/src/SimpleAuthentication/BasicAuthentication/BasicAuthenticationHandler.cs
@@ -59,9 +59,12 @@ internal partial class BasicAuthenticationHandler(IOptionsMonitor<BasicAuthentic
         if (credential is not null)
         {
             var claims = new List<Claim>();
-            foreach (var role in credential.Roles)
+            if (credential.Roles is not null)
             {
-                claims.Add(new(Options.RoleClaimType, role));
+                foreach (var role in credential.Roles)
+                {
+                    claims.Add(new(Options.RoleClaimType, role));
+                }
             }
 
             return CreateAuthenticationSuccessResult(credential.UserName, claims);

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.3" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.4" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated SimpleAuthenticationTools.Abstractions package to version 3.1.4 in both SimpleAuthentication.Swashbuckle.csproj and SimpleAuthentication.csproj for potential bug fixes and improvements.

Added null checks for Roles in ApiKeyAuthenticationHandler.cs and BasicAuthenticationHandler.cs to prevent runtime exceptions when iterating over potentially null collections.