### PR TITLE
Update .NET version to 10.x in workflow files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '9.x'
+  NET_VERSION: '10.x'
   PROJECT_NAME: src/SimpleAuthentication 
   PROJECT_FILE: SimpleAuthentication.csproj
   RELEASE_NAME: SimpleAuthenticationTools

--- a/.github/workflows/publish_abstractions.yml
+++ b/.github/workflows/publish_abstractions.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '9.x'
+  NET_VERSION: '10.x'
   PROJECT_NAME: src/SimpleAuthentication.Abstractions 
   PROJECT_FILE: SimpleAuthentication.Abstractions.csproj
   TAG_NAME: abstractions

--- a/.github/workflows/publish_swashbuckle.yml
+++ b/.github/workflows/publish_swashbuckle.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '9.x'
+  NET_VERSION: '10.x'
   PROJECT_NAME: src/SimpleAuthentication.Swashbuckle 
   PROJECT_FILE: SimpleAuthentication.Swashbuckle.csproj
   TAG_NAME: swashbuckle


### PR DESCRIPTION
Updated the `NET_VERSION` environment variable from `9.x` to `10.x` in the following GitHub Actions workflow files:
- `publish.yml` for the `src/SimpleAuthentication` project
- `publish_abstractions.yml` for the `src/SimpleAuthentication.Abstractions` project
- `publish_swashbuckle.yml` for the `src/SimpleAuthentication.Swashbuckle` project

This ensures that the projects are built and published using the latest .NET 10.x framework.