### PR TITLE
Simplify OpenApiHelpers Schema initialization

### DIFF
--- a/src/SimpleAuthentication.Swashbuckle/Swagger/OpenApiHelpers.cs
+++ b/src/SimpleAuthentication.Swashbuckle/Swagger/OpenApiHelpers.cs
@@ -21,13 +21,6 @@ internal static class OpenApiHelpers
                 [MediaTypeNames.Application.ProblemJson] = new()
                 {
                     Schema = new OpenApiSchemaReference(nameof(ProblemDetails))
-                    {
-                        Reference = new()
-                        {
-                            Type = ReferenceType.Schema,
-                            Id = nameof(ProblemDetails)
-                        }
-                    }
                 }
             }
         };

--- a/src/SimpleAuthentication/OpenApi/OpenApiHelpers.cs
+++ b/src/SimpleAuthentication/OpenApi/OpenApiHelpers.cs
@@ -70,13 +70,6 @@ internal static class OpenApiHelpers
                 [MediaTypeNames.Application.ProblemJson] = new()
                 {
                     Schema = new OpenApiSchemaReference(nameof(ProblemDetails))
-                    {
-                        Reference = new()
-                        {
-                            Type = ReferenceType.Schema,
-                            Id = nameof(ProblemDetails)
-                        }
-                    }
                 }
             }
         };


### PR DESCRIPTION
Refactor the `Schema` property in the `OpenApiHelpers` class to remove the nested `Reference` property initialization. The `Schema` property for `MediaTypeNames.Application.ProblemJson` is now directly initialized with an `OpenApiSchemaReference` using `nameof(ProblemDetails)`, reducing complexity and improving readability.