### PR TITLE
Update workflows and JwtBearer package versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Publish SimpleAuthentication on NuGet
 
 permissions:
-  contents: read
-  packages: write
-  actions: write
+  contents: write
  
 on:
   push:
@@ -47,11 +45,11 @@ jobs:
       run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json  
       
     - name: Create release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v2
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
           tag_name: v${{ steps.nbgv.outputs.NuGetPackageVersion }}
-          release_name: ${{ env.RELEASE_NAME }} ${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          name: ${{ env.RELEASE_NAME }} ${{ steps.nbgv.outputs.NuGetPackageVersion }}
           draft: false
           prerelease: false

--- a/.github/workflows/publish_abstractions.yml
+++ b/.github/workflows/publish_abstractions.yml
@@ -1,9 +1,7 @@
 name: Publish Abstractions on NuGet
 
 permissions:
-  contents: read
-  packages: write
-  actions: write
+  contents: write
  
 on:
   push:
@@ -48,11 +46,11 @@ jobs:
       run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json  
       
     - name: Create release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v2
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          tag_name: ${{ env.TAG_NAME }}_v${{ steps.nbgv.outputs.NuGetPackageVersion }}
-          release_name: ${{ env.RELEASE_NAME }} ${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          tag_name: v${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          name: ${{ env.RELEASE_NAME }} ${{ steps.nbgv.outputs.NuGetPackageVersion }}
           draft: false
           prerelease: false

--- a/.github/workflows/publish_swashbuckle.yml
+++ b/.github/workflows/publish_swashbuckle.yml
@@ -1,9 +1,7 @@
 name: Publish Swashbuckle for Simple Authentication on NuGet
 
 permissions:
-  contents: read
-  packages: write
-  actions: write
+  contents: write
  
 on:
   push:
@@ -48,11 +46,11 @@ jobs:
       run: dotnet nuget push *.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json  
       
     - name: Create release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v2
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          tag_name: ${{ env.TAG_NAME }}_v${{ steps.nbgv.outputs.NuGetPackageVersion }}
-          release_name: ${{ env.RELEASE_NAME }} ${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          tag_name: v${{ steps.nbgv.outputs.NuGetPackageVersion }}
+          name: ${{ env.RELEASE_NAME }} ${{ steps.nbgv.outputs.NuGetPackageVersion }}
           draft: false
           prerelease: false

--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,15 +28,15 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.23" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.12" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
- Refactored GitHub Actions workflows to use softprops/action-gh-release@v2, unified permissions to contents: write, and standardized release step parameters.
- Updated Microsoft.AspNetCore.Authentication.JwtBearer to latest patch versions for .NET 8.0, 9.0, and 10.0 in Abstractions project.