### PR TITLE
Update actions and bump Abstractions package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         
     - name: Setup .NET SDK ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.NET_VERSION }}
         dotnet-quality: 'ga'

--- a/.github/workflows/publish_abstractions.yml
+++ b/.github/workflows/publish_abstractions.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         
     - name: Setup .NET SDK ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.NET_VERSION }}
         dotnet-quality: 'ga'

--- a/.github/workflows/publish_swashbuckle.yml
+++ b/.github/workflows/publish_swashbuckle.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         
     - name: Setup .NET SDK ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.NET_VERSION }}
         dotnet-quality: 'ga'

--- a/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
+++ b/src/SimpleAuthentication.Swashbuckle/SimpleAuthentication.Swashbuckle.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.10" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.11" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
     </ItemGroup>
 

--- a/src/SimpleAuthentication/SimpleAuthentication.csproj
+++ b/src/SimpleAuthentication/SimpleAuthentication.csproj
@@ -39,7 +39,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.10" />
+        <PackageReference Include="SimpleAuthenticationTools.Abstractions" Version="3.1.11" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgraded actions/checkout to v6 and setup-dotnet to v5 in all publish workflows. Updated SimpleAuthenticationTools.Abstractions to version 3.1.11 in both SimpleAuthentication.csproj and SimpleAuthentication.Swashbuckle.csproj.