### PR TITLE
Update JwtBearer package to latest patch versions

### DIFF
--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,15 +28,15 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.25" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.14" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.15" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Updated Microsoft.AspNetCore.Authentication.JwtBearer NuGet package references in SimpleAuthentication.Abstractions.csproj to the latest patch versions for .NET 8.0, 9.0, and 10.0. This ensures the project uses the most recent security and bug fixes.