### PR TITLE
Update IJwtBearerService claims type and JwtBearer versions

### DIFF
--- a/src/SimpleAuthentication.Abstractions/JwtBearer/IJwtBearerService.cs
+++ b/src/SimpleAuthentication.Abstractions/JwtBearer/IJwtBearerService.cs
@@ -21,7 +21,7 @@ public interface IJwtBearerService
     /// <returns>The JWT bearer token.</returns>
     /// <exception cref="ArgumentException"><paramref name="absoluteExpiration"/> is &lt; DateTime.UtcNow.</exception>    
     [Obsolete("This method has been deprecated and will be removed in a future version. Use CreateTokenAsync instead.")]
-    string CreateToken(string userName, IList<Claim>? claims = null, string? issuer = null, string? audience = null, DateTime? absoluteExpiration = null)
+    string CreateToken(string userName, IEnumerable<Claim>? claims = null, string? issuer = null, string? audience = null, DateTime? absoluteExpiration = null)
         => CreateTokenAsync(userName, claims, issuer, audience, absoluteExpiration).ConfigureAwait(false).GetAwaiter().GetResult();
 
     /// <summary>
@@ -34,7 +34,7 @@ public interface IJwtBearerService
     /// <param name="absoluteExpiration">The absolute expiration of the token. If <see langword="null"/>, the expiration time specified in the configuration will be used, if any.</param>
     /// <returns>The JWT bearer token.</returns>
     /// <exception cref="ArgumentException"><paramref name="absoluteExpiration"/> is &lt; DateTime.UtcNow.</exception>    
-    Task<string> CreateTokenAsync(string userName, IList<Claim>? claims = null, string? issuer = null, string? audience = null, DateTime? absoluteExpiration = null);
+    Task<string> CreateTokenAsync(string userName, IEnumerable<Claim>? claims = null, string? issuer = null, string? audience = null, DateTime? absoluteExpiration = null);
 
     /// <summary>
     /// Reads and validates a 'JSON Web Token' (JWT) encoded as a JWS or JWE in Compact Serialized Format.

--- a/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
+++ b/src/SimpleAuthentication.Abstractions/SimpleAuthentication.Abstractions.csproj
@@ -28,15 +28,15 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.28" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.15" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.17" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Changed claims parameter to IEnumerable<Claim>? in IJwtBearerService for greater flexibility. Updated obsolete CreateToken to call CreateTokenAsync synchronously. Bumped Microsoft.AspNetCore.Authentication.JwtBearer package versions for .NET 8, 9, and 10 targets.